### PR TITLE
Fixed hasDatabaseFamily and hasDatabaseEngine typos

### DIFF
--- a/lite-uda-installer-archives-mapping.ttl
+++ b/lite-uda-installer-archives-mapping.ttl
@@ -8747,8 +8747,8 @@ source:
     oplinst:hasInstallerArchiveCategory <http://data.openlinksw.com/oplweb/component_category/STLiteInstaller#this> ;
     oplinst:isInstallerArchiveOf <http://data.openlinksw.com/oplweb/product_release/UDASingleTierLiteEditionODBCRelease8ODBCBridge#this> ;
     oplpro:versionText "8.0" ;
-    oplsof:hasDatabaseEngine oplsof:ODBC ;
-    oplsof:hasDatabaseFamily oplsof:ODBC ;
+    oplsof:hasDatabaseEngine oplsof:odbc ;
+    oplsof:hasDatabaseFamily oplsof:ODBCBridge ;
     oplsof:hasDbmsEngineVersion "3.5" ;
     oplsof:hasOperatingSystem <http://data.openlinksw.com/oplweb/opsys/x86_64-generic-win-64#this> ;
     oplsof:hasOperatingSystemFamily oplsof:Windows ;


### PR DESCRIPTION
Fixed typos in the objects of the oplsof:hasDatabaseEngine and oplsof:hasDatabaseFamily relations for the release 8 odbc bridge 