### PR TITLE
Updated the oplinst:hasInstallerArchiveCategory for the release 8 Win…

### DIFF
--- a/enterprise-uda-installer-archives-mapping.ttl
+++ b/enterprise-uda-installer-archives-mapping.ttl
@@ -29,7 +29,7 @@ sourceDAV:
    dcterms:format "text/turtle" ;
    cc:attributionURL <http://www.openlinksw.com/dataspace/organization/openlink#this> ;
    schema:dateCreated  "2015-08-20T18:00:00-05:00"^^xsd:dateTime ;
-   schema:dateModified "2022-10-14T11:46:00-00:00"^^xsd:dateTime ;
+   schema:dateModified "2022-10-18T11:46:00-00:00"^^xsd:dateTime ;
    schema:license <http://creativecommons.org/licenses/by/4.0/deed.en_US> ;
    owl:sameAs source: .
 


### PR DESCRIPTION
…dows Informix agent Installer

The category is now
<http://data.openlinksw.com/oplweb/component_category/MTServerDBInstaller#this> in line with the other database agent installers