### PR TITLE
various fixes to applications.ttl

### DIFF
--- a/applications.ttl
+++ b/applications.ttl
@@ -24,1203 +24,1204 @@
 @prefix comp:      <http://virtuoso.openlinksw.com/data/turtle/utilities/apps-and-services.ttl#> .
 
 source: a schema:CreativeWork ;
-  schema:comment """Description of OpenLink Software Applications and VAD Packages."""^^xsd:string ;
-  schema:dateCreated  "2014-07-03T15:44:00-05:00"^^xsd:dateTime ;
-  schema:dateModified "2023-10-05T17:35:44+01:00"^^xsd:dateTime ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  xhv:license <http://creativecommons.org/licenses/by/4.0/deed.en_US> ;
-  cc:attributionName "OpenLink Software" ;
-  cc:attributionURL <http://www.openlinksw.com/dataspace/organization/openlink#this> ;
-  schema:about
-              :DBpedia ,
-              :DBpediaGitRepo ,
-              :DBpediaVad ,
-              :Fct ,
-              :FctVad ,
-              :FctGitRepo ,
-              :Cartridges ,
-              :CartridgesVad ,
-              :CartridgesGitRepo ,
-              :InclusionEngine ,
-              :InclusionEngineVad ,
-              :InclusionEngineGitRepo ,
-              :Ods ,
-              :OdsGitRepo ,
-              :OdsFrameworkVad ,
-              :OdsBookmarkVad ,
-              :Odsui ,
-              :OdsuiVad ,
-              :OdsuiGitRepo ,
-              :OdsShopcart ,
-              :OdsShopcartVad ,
-              :OdsShopcartGitRepo ,
-              :OplShop ,
-              :OplShopVad ,
-              :OplShopGitRepo ,
-              :DomPdf ,
-              :DomPdfVad ,
-              :DomPdfGitRepo ,
-              :OdsConsole ,
-              :OdsConsoleVad ,
-              :OdsConsoleGitRepo ,
-              :OpenlinkWWWProducts ,
-              :OpenlinkWWWProductsGitRepo ,
-              :OpenlinkWWWProductsVad ,
-              :OdsWebPage ,
-              :OdsWebPageVad ,
-              :OdsWebPageGitRepo ,
-              :Cartridges ,
-              :CartridgesVad ,
-              :CartridgesGitRepo ,
-              :VirtuosoEngine ,
-              :VirtuosoEngineGitRepo ,
-              :OnlineShopSystem ,
-              :OnlineShopAdministration ,
-              :OnlineShopQuoteGenerator ,
-              :OnlineShopCustomerQuoteGenerator ,
-              :OnlineShopFreeQuoteGenerator ,
-              :OnlineShopHistory,
-	      :OdsWikiVad,
-	      :OdsDiscussionVad,
-	      :OdsGalleryVad,
-	      :OdsPollsVad,
-              :DocumentationVad,
-              :ValVad,
-              :ISparqlVad,
-              :Html5PivotViewer,
-              :SchoolsVad,
-              :OatVad,
-              :R2RMLVad,
-              :SparqlCxmlVad,
-              :SyncMLVad,
-	      :CUriVad,
-              :Phpbb3Vad,
-              :MediaWikiVad,
-              :WordpressVad,
-              :ConductorVAD,
-              :SupportSystem,
-              :SupportSystemGitRepo,
-              :SupportSystemVad,
-              :LicenseGenerator,
-              :LicenseGeneratorGitRepo,
-              :LicenseGeneratorVad,
-              :OdsProfile,
-              :OdsProfileGotRepo,
-              :OdsProfileVAD,
-              :OplSkins,
-              :OplSkinsGitRepo,
-              :OplSkinsVad,
-              :Log4Virtuoso,
-              :Log4VirtuosoGitRepo,
-              :Log4VirtuosoVad,
-	      :PersonalAssitantVad .
+	schema:comment """Description of OpenLink Software Applications and VAD Packages."""^^xsd:string ;
+	schema:dateCreated  "2014-07-03T15:44:00-05:00"^^xsd:dateTime ;
+	schema:dateModified "2023-10-11T13:35:00-04:00"^^xsd:dateTime ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	xhv:license <http://creativecommons.org/licenses/by/4.0/deed.en_US> ;
+	cc:attributionName "OpenLink Software" ;
+	cc:attributionURL <http://www.openlinksw.com/dataspace/organization/openlink#this> ;
+	schema:about
+			:DBpedia ,
+			:DBpediaGitRepo ,
+			:DBpediaVad ,
+			:Fct ,
+			:FctVad ,
+			:FctGitRepo ,
+			:Cartridges ,
+			:CartridgesVad ,
+			:CartridgesGitRepo ,
+			:InclusionEngine ,
+			:InclusionEngineVad ,
+			:InclusionEngineGitRepo ,
+			:Ods ,
+			:OdsGitRepo ,
+			:OdsFrameworkVad ,
+			:OdsBookmarkVad ,
+			:Odsui ,
+			:OdsuiVad ,
+			:OdsuiGitRepo ,
+			:OdsShopcart ,
+			:OdsShopcartVad ,
+			:OdsShopcartGitRepo ,
+			:OplShop ,
+			:OplShopVad ,
+			:OplShopGitRepo ,
+			:DomPdf ,
+			:DomPdfVad ,
+			:DomPdfGitRepo ,
+			:OdsConsole ,
+			:OdsConsoleVad ,
+			:OdsConsoleGitRepo ,
+			:OpenlinkWWWProducts ,
+			:OpenlinkWWWProductsGitRepo ,
+			:OpenlinkWWWProductsVad ,
+			:OdsWebPage ,
+			:OdsWebPageVad ,
+			:OdsWebPageGitRepo ,
+			:Cartridges ,
+			:CartridgesVad ,
+			:CartridgesGitRepo ,
+			:VirtuosoEngine ,
+			:VirtuosoEngineGitRepo ,
+			:OnlineShopSystem ,
+			:OnlineShopAdministration ,
+			:OnlineShopQuoteGenerator ,
+			:OnlineShopCustomerQuoteGenerator ,
+			:OnlineShopFreeQuoteGenerator ,
+			:OnlineShopHistory,
+			:OdsWikiVad,
+			:OdsDiscussionVad,
+			:OdsGalleryVad,
+			:OdsPollsVad,
+			:DocumentationVad,
+			:ValVad,
+			:ISparqlVad,
+			:Html5PivotViewer,
+			:SchoolsVad,
+			:OatVad,
+			:R2RMLVad,
+			:SparqlCxmlVad,
+			:SyncMLVad,
+			:CUriVad,
+			:Phpbb3Vad,
+			:MediaWikiVad,
+			:WordpressVad,
+			:ConductorVAD,
+			:SupportSystem,
+			:SupportSystemGitRepo,
+			:SupportSystemVad,
+			:LicenseGenerator,
+			:LicenseGeneratorGitRepo,
+			:LicenseGeneratorVad,
+			:OdsProfile,
+			:OdsProfileGotRepo,
+			:OdsProfileVAD,
+			:OplSkins,
+			:OplSkinsGitRepo,
+			:OplSkinsVad,
+			:Log4Virtuoso,
+			:Log4VirtuosoGitRepo,
+			:Log4VirtuosoVad,
+			:PA ,
+			:PAVad , ## @TallTed changed from :PersonalAssitantVad which also included a typo
+			:PAGitRepo .
 
 sourceDAV:
-  a schema:CreativeWork ;
-  schema:comment """Description of OpenLink Software Applications and VAD Packages."""^^xsd:string ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  xhv:license <http://creativecommons.org/licenses/by/4.0/deed.en_US> ;
-  cc:attributionName "OpenLink Software" ;
-  cc:attributionURL <http://www.openlinksw.com/dataspace/organization/openlink#this> ;
-  owl:sameAs source: .
+	a schema:CreativeWork ;
+	schema:comment """Description of OpenLink Software Applications and VAD Packages."""^^xsd:string ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	xhv:license <http://creativecommons.org/licenses/by/4.0/deed.en_US> ;
+	cc:attributionName "OpenLink Software" ;
+	cc:attributionURL <http://www.openlinksw.com/dataspace/organization/openlink#this> ;
+	owl:sameAs source: .
 
 ### Personal Assistant
 
 :PA a doap:Project, schema:SoftwareApplication ;
-  doap:name "Personal Assistant" ;
-  doap:description """The Personal Assistant is a ChatGPT-based application that offers product-related conversational self-help and support via loose coupling with Knowledge Graphs -- a concept also known as Retrieval Augmented Generation (RAG).""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:maintainer <http://www.openlinksw.com/dataspace/organization/openlink#this> ;
-  doap:repository :PAGitRepo ;
-  oplvad:hasVadPackage :PAVad ;
-  wdrs:describedby source: .
+	doap:name "Personal Assistant" ;
+	doap:description """The Personal Assistant is a ChatGPT-based application that offers conversational product-related self-help and support via loose coupling with Knowledge Graphs — a concept also known as Retrieval Augmented Generation (RAG).""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:maintainer <http://www.openlinksw.com/dataspace/organization/openlink#this> ;
+	doap:repository :PAGitRepo ;
+	oplvad:hasVadPackage :PAVad ;
+	wdrs:describedby source: .
 
 :PAGitRepo a doap:GitRepository ;
-  schema:name "Personal Assistant Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Personal Assistant Git Repository" ;
+	wdrs:describedby source: .
 
 :PAVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/personal_assistant_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Personal Assistant VAD" ;
-  schema:comment "Personal Assistant VAD" ;
-  oplvad:hasPackageName "personal_assistant"^^xsd:string ;
-  oplvad:hasFileName "personal_assistant_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :PA ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/personal_assistant_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Personal Assistant VAD" ;
+	schema:comment "Personal Assistant VAD" ;
+	oplvad:hasPackageName "personal_assistant"^^xsd:string ;
+	oplvad:hasFileName "personal_assistant_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :PA ;
+	wdrs:describedby source: .
 
 #DBpedia
 
 :DBpedia a doap:Project, schema:SoftwareApplication ;
-  doap:name "DBpedia" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:maintainer <http://www.openlinksw.com/dataspace/organization/openlink#this> ;
-  doap:repository :DBpediaGitRepo ;
-  oplvad:hasVadPackage :DBpediaVad ;
-  wdrs:describedby source: .
+	doap:name "DBpedia" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:maintainer <http://www.openlinksw.com/dataspace/organization/openlink#this> ;
+	doap:repository :DBpediaGitRepo ;
+	oplvad:hasVadPackage :DBpediaVad ;
+	wdrs:describedby source: .
 
 :DBpediaGitRepo a doap:GitRepository ;
-  schema:name "DBpediaGitRepo Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "DBpediaGitRepo Git Repository" ;
+	wdrs:describedby source: .
 
 :DBpediaVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/dbpedia_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "DBpedia VAD" ;
-  schema:comment "DBpedia VAD" ;
-  oplvad:hasPackageName "DBpedia"^^xsd:string ;
-  oplvad:hasFileName "dbpedia_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :DBpedia ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/dbpedia_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "DBpedia VAD" ;
+	schema:comment "DBpedia VAD" ;
+	oplvad:hasPackageName "DBpedia"^^xsd:string ;
+	oplvad:hasFileName "dbpedia_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :DBpedia ;
+	wdrs:describedby source: .
 
 
 ### Faceted Browser
 
 :Fct a doap:Project, schema:SoftwareApplication ;
-  doap:name "Faceted Browser" ;
-  doap:description """The Virtuoso Faceted Browser service is a general purpose RDF data query facility for faceted browsing over entity relationship types.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:maintainer <http://www.openlinksw.com/dataspace/organization/openlink#this> ;
-  doap:repository :FctGitRepo ;
-  oplvad:hasVadPackage :FctVad ;
-  wdrs:describedby source: .
+	doap:name "Faceted Browser" ;
+	doap:description """The Virtuoso Faceted Browser service is a general purpose RDF data query facility for faceted browsing over entity relationship types.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:maintainer <http://www.openlinksw.com/dataspace/organization/openlink#this> ;
+	doap:repository :FctGitRepo ;
+	oplvad:hasVadPackage :FctVad ;
+	wdrs:describedby source: .
 
 :FctGitRepo a doap:GitRepository ;
-  schema:name "Facet Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Facet Git Repository" ;
+	wdrs:describedby source: .
 
 :FctVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/fct_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Faceted Browser VAD" ;
-  schema:comment "Faceted Browser VAD" ;
-  oplvad:hasPackageName "fct"^^xsd:string ;
-  oplvad:hasFileName "fct_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Fct ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/fct_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Faceted Browser VAD" ;
+	schema:comment "Faceted Browser VAD" ;
+	oplvad:hasPackageName "fct"^^xsd:string ;
+	oplvad:hasFileName "fct_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Fct ;
+	wdrs:describedby source: .
 
 
 ### Cartridges
 
 :Cartridges a doap:Project, schema:SoftwareApplication ;
-  doap:name "Linked Data Cartridges" ;
-  doap:description """The Sponger Linked Data Cartridges which allow to convert data from all types of source into RDF data.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :CartridgesGitRepo ;
-  oplvad:hasVadPackage :CartridgesVad ;
-  wdrs:describedby source: .
+	doap:name "Linked Data Cartridges" ;
+	doap:description """The Sponger Linked Data Cartridges which allow to convert data from all types of source into RDF data.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :CartridgesGitRepo ;
+	oplvad:hasVadPackage :CartridgesVad ;
+	wdrs:describedby source: .
 
 :CartridgesGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Linked Data Cartridges Git Repository" ;
+	wdrs:describedby source: .
 
 :CartridgesVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/cartridges_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Linked Data Cartridges VAD" ;
-  oplvad:hasPackageName "cartridges"^^xsd:string ;
-  oplvad:hasOptionalDependency :ValVad ;
-  oplvad:hasFileName "cartridges_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Cartridges ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/cartridges_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Linked Data Cartridges VAD" ;
+	oplvad:hasPackageName "cartridges"^^xsd:string ;
+	oplvad:hasOptionalDependency :ValVad ;
+	oplvad:hasFileName "cartridges_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Cartridges ;
+	wdrs:describedby source: .
 
 
 ### Inclusion-Engine
 
 :InclusionEngine a doap:Project, schema:SoftwareApplication ;
-  doap:name "Inclusion Engine" ;
-  doap:description """The Inclusion Engine which powers the OpenLink web pages.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :InclusionEngineGitRepo ;
-  oplvad:hasVadPackage :InclusionEngineVad ;
-  wdrs:describedby source: .
+	doap:name "Inclusion Engine" ;
+	doap:description """The Inclusion Engine which powers the OpenLink web pages.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :InclusionEngineGitRepo ;
+	oplvad:hasVadPackage :InclusionEngineVad ;
+	wdrs:describedby source: .
 
 :InclusionEngineGitRepo a doap:GitRepository ;
-  schema:name "Inclusion Engine Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Inclusion Engine Git Repository" ;
+	wdrs:describedby source: .
 
 :InclusionEngineVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Inclusion Engine VAD" ;
-  oplvad:hasPackageName "inclusion-engine"^^xsd:string ;
-  oplvad:hasOptionalDependency :OdsuiVad ;
-  oplvad:hasOptionalDependency :VALVad ;
-  oplvad:hasOptionalDependency :CUriVad ;
-  oplvad:hasOptionalDependency :CartridgesVad ;
-  oplvad:hasFileName "inclusion-engine_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :InclusionEngine ;
-  wdrs:describedby source: .
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Inclusion Engine VAD" ;
+	oplvad:hasPackageName "inclusion-engine"^^xsd:string ;
+	oplvad:hasOptionalDependency :OdsuiVad ;
+	oplvad:hasOptionalDependency :VALVad ;
+	oplvad:hasOptionalDependency :CUriVad ;
+	oplvad:hasOptionalDependency :CartridgesVad ;
+	oplvad:hasFileName "inclusion-engine_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :InclusionEngine ;
+	wdrs:describedby source: .
 
 
 ### ODS
 
 :Ods a doap:Project, schema:SoftwareApplication ;
-  doap:name "OpenLink Data Spaces (ODS)" ;
-  doap:shortdesc """OpenLink Data Spaces describes a suite of web-enabled distributed collaborative applications
-    that provide social-networking, file-sharing, content aggregation and publishing etc. across one or more
-    loosely coupled "points of presence" (nodes) on the Internet.""" ;
-  doap:description """OpenLink Data Spaces (ODS) is a distributed collaborative application platform for creating
-    Semantic Web presence from Web 2.0 application profiles such as: Weblogs, Wikis, Feed Aggregators, Bookmark
-    Mangers and more via an RDF based metadata model that incorporates
-    shared ontologies such as SIOC, FOAF, and Atom OWL alongside in-built support for generic query services
-    such as SPARQL, GData, and OpenSearch amongst others. ODS is an application of Virtuoso, OpenLink's
-    Universal Server platform and is available in Open Source and Commercial Editions.""" ;
-  doap:programming-language "C"^^xsd:string,
-                            "RDF"^^xsd:string,
-                            "OWL"^^xsd:string,
-                            "Javascript"^^xsd:string,
-                            "PHP"^^xsd:string,
-                            "SPARQL"^^xsd:string,
-                            "XHTML"^^xsd:string,
-                            "SVG"^^xsd:string ;
-  doap:created "2006-08-08"^^xsd:date ;
-  doap:category <http://projects.apache.org/category/database> ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :OdsGitRepo ;
-  oplvad:hasVadPackage
-    :OdsFrameworkVad ,
-    :OdsBookmarkVad ,
-    :OdsAddressbookVad ,
-    :OdsBriefcaseVad ,
-    :OdsFeedmanagerVad ,
-    :OdsBlogVad ,
-    :OdsCalendarVad ,
-    :OdsWebmailVad ,
-    :OdsApidoxVad ,
-    :OdsWikiVad ;
-  wdrs:describedby source: .
+	doap:name "OpenLink Data Spaces (ODS)" ;
+	doap:shortdesc """OpenLink Data Spaces describes a suite of web-enabled distributed collaborative applications
+		that provide social-networking, file-sharing, content aggregation and publishing etc. across one or more
+		loosely coupled "points of presence" (nodes) on the Internet.""" ;
+	doap:description """OpenLink Data Spaces (ODS) is a distributed collaborative application platform for creating
+		Semantic Web presence from Web 2.0 application profiles such as: Weblogs, Wikis, Feed Aggregators, Bookmark
+		Mangers and more via an RDF based metadata model that incorporates
+		shared ontologies such as SIOC, FOAF, and Atom OWL alongside in-built support for generic query services
+		such as SPARQL, GData, and OpenSearch, amongst others. ODS is an application of Virtuoso, OpenLink's
+		Universal Server platform, and is available in Open Source and Commercial Editions.""" ;
+	doap:programming-language "C"^^xsd:string,
+		"RDF"^^xsd:string,
+		"OWL"^^xsd:string,
+		"Javascript"^^xsd:string,
+		"PHP"^^xsd:string,
+		"SPARQL"^^xsd:string,
+		"XHTML"^^xsd:string,
+		"SVG"^^xsd:string ;
+	doap:created "2006-08-08"^^xsd:date ;
+	doap:category <http://projects.apache.org/category/database> ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :OdsGitRepo ;
+	oplvad:hasVadPackage
+		:OdsFrameworkVad ,
+		:OdsBookmarkVad ,
+		:OdsAddressbookVad ,
+		:OdsBriefcaseVad ,
+		:OdsFeedmanagerVad ,
+		:OdsBlogVad ,
+		:OdsCalendarVad ,
+		:OdsWebmailVad ,
+		:OdsApidoxVad ,
+		:OdsWikiVad ;
+	wdrs:describedby source: .
 
 :OdsGitRepo a doap:GitRepository ;
-  schema:name "ODS Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "ODS Git Repository" ;
+	wdrs:describedby source: .
 
 :OdsFrameworkVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_framework_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Framework VAD" ;
-  oplvad:hasPackageName "Framework"^^xsd:string ;
-  oplvad:hasFileName "ods_framework_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_framework_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Framework VAD" ;
+	oplvad:hasPackageName "Framework"^^xsd:string ;
+	oplvad:hasFileName "ods_framework_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsBookmarkVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_bookmark_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Bookmark VAD" ;
-  oplvad:hasPackageName "Bookmarks"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasFileName "ods_bookmarks_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_bookmark_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Bookmark VAD" ;
+	oplvad:hasPackageName "Bookmarks"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasFileName "ods_bookmarks_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsAddressbookVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_addressbook_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Addressbook VAD" ;
-  oplvad:hasPackageName "AddressBook"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasFileName "ods_addressbook_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_addressbook_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Addressbook VAD" ;
+	oplvad:hasPackageName "AddressBook"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasFileName "ods_addressbook_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsBriefcaseVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_briefcase_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Briefcase VAD" ;
-  oplvad:hasPackageName "Briefcase"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasFileName "ods_briefcase_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_briefcase_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Briefcase VAD" ;
+	oplvad:hasPackageName "Briefcase"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasFileName "ods_briefcase_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsFeedmanagerVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_feedmanager_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Feedmanager VAD" ;
-  oplvad:hasPackageName "Feed Manager"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad , :OdsBlogVad ;
-  oplvad:hasFileName "ods_feedmanager_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_feedmanager_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Feedmanager VAD" ;
+	oplvad:hasPackageName "Feed Manager"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad , :OdsBlogVad ;
+	oplvad:hasFileName "ods_feedmanager_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsBlogVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_blog_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Weblog VAD" ;
-  oplvad:hasPackageName "Weblog"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasFileName "ods_blog_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_blog_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Weblog VAD" ;
+	oplvad:hasPackageName "Weblog"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasFileName "ods_blog_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsCalendarVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_calendar_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Calendar VAD" ;
-  oplvad:hasPackageName "Calendar"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasFileName "ods_calandar_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_calendar_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Calendar VAD" ;
+	oplvad:hasPackageName "Calendar"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasFileName "ods_calandar_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsWebmailVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_webmail_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Webmail VAD" ;
-  oplvad:hasPackageName "Mail"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasFileName "ods_webmail_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_webmail_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Webmail VAD" ;
+	oplvad:hasPackageName "Mail"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasFileName "ods_webmail_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsApidoxVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS API Dox VAD" ;
-  schema:comment "VAD which will install the ODS API Documentation accessible at /apidox." ;
-  oplvad:hasPackageName "Apidox"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasFileName "ods_apidox_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS API Dox VAD" ;
+	schema:comment "VAD which will install the ODS API Documentation accessible at /apidox." ;
+	oplvad:hasPackageName "Apidox"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasFileName "ods_apidox_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsWikiVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_wiki_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Wiki VAD" ;
-  oplvad:hasPackageName "Wiki"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasFileName "ods_wiki_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_wiki_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Wiki VAD" ;
+	oplvad:hasPackageName "Wiki"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasFileName "ods_wiki_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsDiscussionVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_discussion_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Discussion VAD" ;
-  oplvad:hasPackageName "Discussion"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasFileName "ods_discussion_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_discussion_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Discussion VAD" ;
+	oplvad:hasPackageName "Discussion"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasFileName "ods_discussion_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsGalleryVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_gallery_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Gallery VAD" ;
-  oplvad:hasPackageName "Gallery"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasFileName "ods_gallery_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_gallery_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Gallery VAD" ;
+	oplvad:hasPackageName "Gallery"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasFileName "ods_gallery_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 :OdsPollsVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_polls_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Polls VAD" ;
-  oplvad:hasPackageName "Polls"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasFileName "ods_polls_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Ods ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/ods_polls_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Polls VAD" ;
+	oplvad:hasPackageName "Polls"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasFileName "ods_polls_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Ods ;
+	wdrs:describedby source: .
 
 
 ### ODS-UI.vsp
 
 :Odsui a doap:Project, schema:SoftwareApplication ;
-  doap:name "ODS-UI" ;
-  doap:description """ODS-UI.vsp provides simple vsp includes and dialogs which allow to authenticate via
-    ODS. Any ODS-powered application can use these to add authentication.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :OdsGitRepo ;
-  oplvad:hasVadPackage :OdsuiVad ;
-  wdrs:describedby source: .
+	doap:name "ODS-UI" ;
+	doap:description """ODS-UI.vsp provides simple vsp includes and dialogs which allow users to authenticate via
+		ODS. Any ODS-powered application can use these to add authentication.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :OdsGitRepo ;
+	oplvad:hasVadPackage :OdsuiVad ;
+	wdrs:describedby source: .
 
 :OdsuiGitRepo a doap:GitRepository ;
-  schema:name "ODS-UI Git Repository" ;
-  oplvad:hasSubDirectory "framework/odsui"^^xsd:string ;
-  wdrs:describedby source: .
+	schema:name "ODS-UI Git Repository" ;
+	oplvad:hasSubDirectory "framework/odsui"^^xsd:string ;
+	wdrs:describedby source: .
 
 :OdsuiVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS-UI VAD" ;
-  oplvad:hasPackageName "ODS-UI.vsp"^^xsd:string ;
-  oplvad:hasFileName "ods-ui.vsp_dav.vad"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:isVadPackageOf :Odsui ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS-UI VAD" ;
+	oplvad:hasPackageName "ODS-UI.vsp"^^xsd:string ;
+	oplvad:hasFileName "ods-ui.vsp_dav.vad"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:isVadPackageOf :Odsui ;
+	wdrs:describedby source: .
 
 
 ### ODS Shopcart
 
 :OdsShopcart a doap:Project, schema:SoftwareApplication ;
-  doap:name "ODS Shopcart" ;
-  doap:description """The ODS Shopcart application provides an API for shopcart management which allows
-    a user to add GoodRelations items to a shopcart, remove them, etc..""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :OdsShopcartGitRepo ;
-  oplvad:hasVadPackage :OdsShopcartVad ;
-  wdrs:describedby source: .
+	doap:name "ODS Shopcart" ;
+	doap:description """The ODS Shopcart application provides an API for shopcart management which allows
+		a user to add GoodRelations items to a shopcart, remove them, etc.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :OdsShopcartGitRepo ;
+	oplvad:hasVadPackage :OdsShopcartVad ;
+	wdrs:describedby source: .
 
 :OdsShopcartGitRepo a doap:GitRepository ;
-  schema:name "ODS Shopcart Git Repository" ;
-
-  wdrs:describedby source: .
+	schema:name "ODS Shopcart Git Repository" ;
+	wdrs:describedby source: .
 
 :OdsShopcartVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Shopcart VAD" ;
-  oplvad:hasPackageName "ods-shopcart"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsFrameworkVad ;
-  oplvad:hasOptionalDependency :CartridgesVad ;
-  oplvad:hasFileName "ods_shopcart_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :OdsShopcart ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Shopcart VAD" ;
+	oplvad:hasPackageName "ods-shopcart"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsFrameworkVad ;
+	oplvad:hasOptionalDependency :CartridgesVad ;
+	oplvad:hasFileName "ods_shopcart_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :OdsShopcart ;
+	wdrs:describedby source: .
 
 
 ### OPL Shop
 
 :OplShop a doap:Project, schema:SoftwareApplication ;
-  doap:name "Openlink Shop" ;
-  doap:description """The OpenLink Shop System provides a UI and procedures to manage offers, purchases, quotes, etc..""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :OplShopGitRepo ;
-  oplvad:hasVadPackage :OplShopVad ;
-  oplcomp:hasComponent :OnlineShopSystem ;
-  wdrs:describedby source: .
+	doap:name "Openlink Shop" ;
+	doap:description """The OpenLink Shop System provides a UI and procedures to manage offers, purchases, quotes, etc.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :OplShopGitRepo ;
+	oplvad:hasVadPackage :OplShopVad ;
+	oplcomp:hasComponent :OnlineShopSystem ;
+	wdrs:describedby source: .
 
 :OplShopGitRepo a doap:GitRepository ;
-  schema:name "Openlink Shop Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Openlink Shop Git Repository" ;
+	wdrs:describedby source: .
 
 :OplShopVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Openlink Shop VAD" ;
-  oplvad:hasPackageName "opl-shop"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsuiVad ;
-  oplvad:hasMandatoryDependency :InclusionEngineVad ;
-  oplvad:hasMandatoryDependency :ValVad ;
-  oplvad:hasOptionalDependency :CartridgesVad ;
-  oplvad:hasOptionalDependency :DomPdfVad ;
-  oplvad:hasFileName "opl_shop_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :OplShop ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Openlink Shop VAD" ;
+	oplvad:hasPackageName "opl-shop"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsuiVad ;
+	oplvad:hasMandatoryDependency :InclusionEngineVad ;
+	oplvad:hasMandatoryDependency :ValVad ;
+	oplvad:hasOptionalDependency :CartridgesVad ;
+	oplvad:hasOptionalDependency :DomPdfVad ;
+	oplvad:hasFileName "opl_shop_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :OplShop ;
+	wdrs:describedby source: .
 
 
 ### DomPDF
 
 :DomPdf a doap:Project, schema:SoftwareApplication ;
-  doap:name "Dom PDF" ;
-  doap:description """The Dom PDF application is a fork of the open-source PHP PDF generator by the same name.""" ;
-  schema:mentions <https://github.com/dompdf/dompdf> ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :DomPdfGitRepo ;
-  oplvad:hasVadPackage :DomPdfVad ;
-  wdrs:describedby source: .
+	doap:name "Dom PDF" ;
+	doap:description """The Dom PDF application is a fork of the open-source PHP PDF generator by the same name.""" ;
+	schema:mentions <https://github.com/dompdf/dompdf> ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :DomPdfGitRepo ;
+	oplvad:hasVadPackage :DomPdfVad ;
+	wdrs:describedby source: .
 
 :DomPdfGitRepo a doap:GitRepository ;
-  schema:name "Dom PDF Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Dom PDF Git Repository" ;
+	wdrs:describedby source: .
 
 :DomPdfVad
-  a oplvad:FileSystemVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Dom PDF VAD" ;
-  oplvad:hasPackageName "dompdf"^^xsd:string ;
-  oplvad:hasFileName "dompdf_fs.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :DomPdf ;
-  wdrs:describedby source: .
+	a oplvad:FileSystemVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Dom PDF VAD" ;
+	oplvad:hasPackageName "dompdf"^^xsd:string ;
+	oplvad:hasFileName "dompdf_fs.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :DomPdf ;
+	wdrs:describedby source: .
 
 
 ### ODS-Console
 
 :OdsConsole a doap:Project, schema:SoftwareApplication ;
-  doap:name "ODS Console" ;
-  doap:description """The ODS Console is a simple UI for the ODS HTTP API which allows to execute any of the ODS API methods.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :OdsConsoleGitRepo ;
-  oplvad:hasVadPackage :OdsConsoleVad ;
-  wdrs:describedby source: .
+	doap:name "ODS Console" ;
+	doap:description """The ODS Console is a simple UI for the ODS HTTP API which allows to execute any of the ODS API methods.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :OdsConsoleGitRepo ;
+	oplvad:hasVadPackage :OdsConsoleVad ;
+	wdrs:describedby source: .
 
 :OdsConsoleGitRepo a doap:GitRepository ;
-  schema:name "ODS Console Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "ODS Console Git Repository" ;
+	wdrs:describedby source: .
 
 :OdsConsoleVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Console VAD" ;
-  oplvad:hasPackageName "ODS-Console"^^xsd:string ;
-  oplvad:hasFileName "ods-console-0.4.1.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :OdsConsole ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Console VAD" ;
+	oplvad:hasPackageName "ODS-Console"^^xsd:string ;
+	oplvad:hasFileName "ods-console-0.4.1.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :OdsConsole ;
+	wdrs:describedby source: .
 
 
 ### Openlink-WWW-Products
 
 :OpenlinkWWWProducts a doap:Project, schema:SoftwareApplication ;
-  doap:name "OpenLink WWW Products" ;
-  doap:description """The OpenLink WWW Products application provides vsp pages to show offer details including metadata.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :OpenlinkWWWProductsGitRepo ;
-  oplvad:hasVadPackage :OpenlinkWWWProductsVad ;
-  wdrs:describedby source: .
+	doap:name "OpenLink WWW Products" ;
+	doap:description """The OpenLink WWW Products application provides vsp pages to show offer details including metadata.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :OpenlinkWWWProductsGitRepo ;
+	oplvad:hasVadPackage :OpenlinkWWWProductsVad ;
+	wdrs:describedby source: .
 
 :OpenlinkWWWProductsGitRepo a doap:GitRepository ;
-  schema:name "OpenLink WWW Products Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "OpenLink WWW Products Git Repository" ;
+	wdrs:describedby source: .
 
 :OpenlinkWWWProductsVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "OpenLink WWW Products VAD" ;
-  oplvad:hasPackageName "prd"^^xsd:string ;
-  oplvad:hasFileName "openlink_www_products_dav.vad"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OplShopVad ;
-  oplvad:isVadPackageOf :OpenlinkWWWProducts ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "OpenLink WWW Products VAD" ;
+	oplvad:hasPackageName "prd"^^xsd:string ;
+	oplvad:hasFileName "openlink_www_products_dav.vad"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OplShopVad ;
+	oplvad:isVadPackageOf :OpenlinkWWWProducts ;
+	wdrs:describedby source: .
 
 
 ### ODS Web Page
 
 :OdsWebPage a doap:Project, schema:SoftwareApplication ;
-  doap:name "ODS Web Page" ;
-  doap:description """The ODS Community Web Page contains documentation and simple profile management.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  schema:mentions <http://web.ods.openlinksw.com/> ;
-  doap:repository :OdsWebPageGitRepo ;
-  oplvad:hasVadPackage :OdsWebPageVad ;
-  wdrs:describedby source: .
+	doap:name "ODS Web Page" ;
+	doap:description """The ODS Community Web Page contains documentation and simple profile management.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	schema:mentions <http://web.ods.openlinksw.com/> ;
+	doap:repository :OdsWebPageGitRepo ;
+	oplvad:hasVadPackage :OdsWebPageVad ;
+	wdrs:describedby source: .
 
 :OdsWebPageGitRepo a doap:GitRepository ;
-  schema:name "ODS Web Page Git Repository" ;
+	schema:name "ODS Web Page Git Repository" ;
 
-  wdrs:describedby source: .
+	wdrs:describedby source: .
 
 :OdsWebPageVad
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Web Page VAD" ;
-  oplvad:hasPackageName "ODS Web Page"^^xsd:string ;
-  oplvad:hasFileName "ods-webpage_dav.vad"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsuiVad ;
-  oplvad:hasOptionalDependency :OdsApidoxVad ;
-  oplvad:isVadPackageOf :OdsWebPage ;
-  wdrs:describedby source: .
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Web Page VAD" ;
+	oplvad:hasPackageName "ODS Web Page"^^xsd:string ;
+	oplvad:hasFileName "ods-webpage_dav.vad"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsuiVad ;
+	oplvad:hasOptionalDependency :OdsApidoxVad ;
+	oplvad:isVadPackageOf :OdsWebPage ;
+	wdrs:describedby source: .
 
 
 ### Virtuoso Engine
 
 :VirtuosoEngine a doap:Project, schema:SoftwareApplication ;
-  doap:name "Virtuoso Engine" ;
-  doap:description "The Virtuoso Engine Project consists of the Virtuoso Universal Server, Documentation and several sub-components." ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :VirtuosoEngineGitRepo ;
-  oplcomp:hasComponent comp:VirtuosoSqlEngine , comp:VirtuosoHttpEngine ;
-  wdrs:describedby source: .
+	doap:name "Virtuoso Engine" ;
+	doap:description "The Virtuoso Engine Project consists of the Virtuoso Universal Server, Documentation and several sub-components." ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :VirtuosoEngineGitRepo ;
+	oplcomp:hasComponent comp:VirtuosoSqlEngine , comp:VirtuosoHttpEngine ;
+	wdrs:describedby source: .
 
 :VirtuosoEngineGitRepo a doap:GitRepository ;
-  schema:name "Virtuoso Engine Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Virtuoso Engine Git Repository" ;
+	wdrs:describedby source: .
 
 :OnlineShopSystem a oplcomp:Component ;
-  schema:name "Online Shop System" ;
-  schema:comment "The Online Shop System including shopcart and purchase management." ;
-  oplcomp:hasSubComponent :OnlineShopAdministration , :OnlineShopQuoteGenerator ;
-  schema:hasPart :OnlineShopAdministration , :OnlineShopQuoteGenerator  ;
-  wdrs:describedby source: .
+	schema:name "Online Shop System" ;
+	schema:comment "The Online Shop System including shopcart and purchase management." ;
+	oplcomp:hasSubComponent :OnlineShopAdministration , :OnlineShopQuoteGenerator ;
+	schema:hasPart :OnlineShopAdministration , :OnlineShopQuoteGenerator  ;
+	wdrs:describedby source: .
 
 :OnlineShopAdministration a oplcomp:Component ;
-  schema:name "Online Shop Administration" ;
-  schema:comment "The Administration System of the Online Shop." ;
-  oplcomp:hasSubComponent :OnlineShopHistory ;
-  oplcomp:isSubComponentOf :OnlineShopSystem ;
-  schema:hasPart :OnlineShopHistory ;
-  schema:isPartOf :OnlineShopSystem  ;
-  wdrs:describedby source: .
+	schema:name "Online Shop Administration" ;
+	schema:comment "The Administration System of the Online Shop." ;
+	oplcomp:hasSubComponent :OnlineShopHistory ;
+	oplcomp:isSubComponentOf :OnlineShopSystem ;
+	schema:hasPart :OnlineShopHistory ;
+	schema:isPartOf :OnlineShopSystem  ;
+	wdrs:describedby source: .
 
 :OnlineShopHistory a oplcomp:Component ;
-  schema:name "Online Shop History" ;
-  schema:comment "The Online Shop History provides administration access to past purchases and quotes." ;
-  oplcomp:isSubComponentOf :OnlineShopAdministration ;
-  schema:isPartOf :OnlineShopAdministration  ;
-  wdrs:describedby source: .
+	schema:name "Online Shop History" ;
+	schema:comment "The Online Shop History provides administration access to past purchases and quotes." ;
+	oplcomp:isSubComponentOf :OnlineShopAdministration ;
+	schema:isPartOf :OnlineShopAdministration  ;
+	wdrs:describedby source: .
 
 :OnlineShopQuoteGenerator a oplcomp:Component ;
-  schema:name "Online Shop Quote Generator" ;
-  schema:comment """The Online Shop Quote Generator allows to create quotes from shopping cart contents.
-    These quotes can either be for the customer themselves or a "free" quote.""" ;
-  oplcomp:isSubComponentOf :OnlineShopSystem ;
-  oplcomp:hasSubComponent :OnlineShopCustomerQuoteGenerator , :OnlineShopFreeQuoteGenerator ;
-  schema:isPartOf :OnlineShopSystem ;
-  schema:hasPart :OnlineShopCustomerQuoteGenerator , :OnlineShopFreeQuoteGenerator  ;
-  wdrs:describedby source: .
+	schema:name "Online Shop Quote Generator" ;
+	schema:comment """The Online Shop Quote Generator allows to create quotes from shopping cart contents.
+		These quotes can either be for the customer themselves or a "free" quote.""" ;
+	oplcomp:isSubComponentOf :OnlineShopSystem ;
+	oplcomp:hasSubComponent :OnlineShopCustomerQuoteGenerator , :OnlineShopFreeQuoteGenerator ;
+	schema:isPartOf :OnlineShopSystem ;
+	schema:hasPart :OnlineShopCustomerQuoteGenerator , :OnlineShopFreeQuoteGenerator  ;
+	wdrs:describedby source: .
 
 :OnlineShopCustomerQuoteGenerator a oplcomp:Component ;
-  schema:name "Online Shop Customer Quote Generator" ;
-  schema:comment "The Customer Quote Generator allows customers to create quotes for themselves only." ;
-  oplcomp:isSubComponentOf :OnlineShopQuoteGenerator ;
-  schema:isPartOf :OnlineShopQuoteGenerator  ;
-  wdrs:describedby source: .
+	schema:name "Online Shop Customer Quote Generator" ;
+	schema:comment "The Customer Quote Generator allows customers to create quotes for themselves only." ;
+	oplcomp:isSubComponentOf :OnlineShopQuoteGenerator ;
+	schema:isPartOf :OnlineShopQuoteGenerator  ;
+	wdrs:describedby source: .
 
 :OnlineShopFreeQuoteGenerator a oplcomp:Component ;
-  schema:name "Online Shop Free Quote Generator" ;
-  schema:comment "The Free Quote Generator allows to generate quotes for anyone." ;
-  oplcomp:isSubComponentOf :OnlineShopQuoteGenerator ;
-  schema:isPartOf :OnlineShopQuoteGenerator  ;
-  wdrs:describedby source: .
+	schema:name "Online Shop Free Quote Generator" ;
+	schema:comment "The Free Quote Generator allows to generate quotes for anyone." ;
+	oplcomp:isSubComponentOf :OnlineShopQuoteGenerator ;
+	schema:isPartOf :OnlineShopQuoteGenerator  ;
+	wdrs:describedby source: .
 
 ### Conductor
 
 :Conductor a doap:Project, schema:SoftwareApplication ;
-  doap:name "Conductor" ;
-  doap:description """The Virtuoso Conductor Administration Interface""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :ConductorGitRepo ;
-  oplvad:hasVadPackage :ConductorVad ;
-  wdrs:describedby source: .
+	doap:name "Conductor" ;
+	doap:description """The Virtuoso Conductor Administration Interface""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :ConductorGitRepo ;
+	oplvad:hasVadPackage :ConductorVad ;
+	wdrs:describedby source: .
 
 :ConductorGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Conductor Git Repository" ;
+	wdrs:describedby source: .
 
 :ConductorVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/conductor_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Conductor VAD" ;
-  oplvad:hasPackageName "conductor"^^xsd:string ;
-  # oplvad:hasOptionalDependency :ValVad ;
-  oplvad:hasFileName "conductor_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Conductor ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/conductor_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Conductor VAD" ;
+	oplvad:hasPackageName "conductor"^^xsd:string ;
+	# oplvad:hasOptionalDependency :ValVad ;
+	oplvad:hasFileName "conductor_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Conductor ;
+	wdrs:describedby source: .
 
 ### Demo Database
 
 :Demo a doap:Project, schema:SoftwareApplication ;
-  doap:name "Demo Database" ;
-  doap:description """The Virtuoso Northwind Demonstration Database""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :DemoGitRepo ;
-  oplvad:hasVadPackage :DemoVad ;
-  wdrs:describedby source: .
+	doap:name "Demo Database" ;
+	doap:description """The Virtuoso Northwind Demonstration Database""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :DemoGitRepo ;
+	oplvad:hasVadPackage :DemoVad ;
+	wdrs:describedby source: .
 
 :DemoGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Demo Database Git Repository" ;
+	wdrs:describedby source: .
 
 :DemoVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/demo_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Demo Database VAD" ;
-  oplvad:hasPackageName "demo"^^xsd:string ;
-  # oplvad:hasOptionalDependency :ValVad ;
-  oplvad:hasFileName "demo_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Demo ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/demo_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Demo Database VAD" ;
+	oplvad:hasPackageName "demo"^^xsd:string ;
+	# oplvad:hasOptionalDependency :ValVad ;
+	oplvad:hasFileName "demo_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Demo ;
+	wdrs:describedby source: .
 
 
 ### Documentation
 
 :Documentation a doap:Project, schema:SoftwareApplication ;
-  doap:name "Documentation" ;
-  doap:description """The Virtuoso Documentation""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :DocumentationGitRepo ;
-  oplvad:hasVadPackage :DocumentationVad ;
-  wdrs:describedby source: .
+	doap:name "Documentation" ;
+	doap:description """The Virtuoso Documentation""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :DocumentationGitRepo ;
+	oplvad:hasVadPackage :DocumentationVad ;
+	wdrs:describedby source: .
 
 :DocumentationGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Documentation Git Repository" ;
+	wdrs:describedby source: .
 
 :DocumentationVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/doc_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Documentation VAD" ;
-  oplvad:hasPackageName "documentation"^^xsd:string ;
-  # oplvad:hasOptionalDependency :ValVad ;
-  oplvad:hasFileName "doc_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Documentation ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/doc_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Documentation VAD" ;
+	oplvad:hasPackageName "documentation"^^xsd:string ;
+	# oplvad:hasOptionalDependency :ValVad ;
+	oplvad:hasFileName "doc_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Documentation ;
+	wdrs:describedby source: .
 
 ### VAL
 
 :VAL a doap:Project, schema:SoftwareApplication ;
-  doap:name "VAL" ;
-  doap:description """The Virtuoso Authentication Layer""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :ValGitRepo ;
-  oplvad:hasVadPackage :ValVad ;
-  wdrs:describedby source: .
+	doap:name "VAL" ;
+	doap:description """The Virtuoso Authentication Layer""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :ValGitRepo ;
+	oplvad:hasVadPackage :ValVad ;
+	wdrs:describedby source: .
 
 :ValGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "VAL Git Repository" ;
+	wdrs:describedby source: .
 
 :ValVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/val_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "VAL VAD" ;
-  oplvad:hasPackageName "val"^^xsd:string ;
-  # oplvad:hasOptionalDependency :ValVad ;
-  oplvad:hasFileName "val_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Val ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/val_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "VAL VAD" ;
+	oplvad:hasPackageName "val"^^xsd:string ;
+	# oplvad:hasOptionalDependency :ValVad ;
+	oplvad:hasFileName "val_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Val ;
+	wdrs:describedby source: .
 
 ### ISPARQL
 
 :ISparql a doap:Project, schema:SoftwareApplication ;
-  doap:name "ISparql" ;
-  doap:description """Interactive SPARQL Query Builder""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :ISparqlGitRepo ;
-  oplvad:hasVadPackage :ISparqlVad ;
-  wdrs:describedby source: .
+	doap:name "ISparql" ;
+	doap:description """Interactive SPARQL Query Builder""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :ISparqlGitRepo ;
+	oplvad:hasVadPackage :ISparqlVad ;
+	wdrs:describedby source: .
 
 :ISparqlGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "ISparql Git Repository" ;
+	wdrs:describedby source: .
 
 :ISparqlVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/isparql_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ISparql VAD" ;
-  oplvad:hasPackageName "ISparql"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "isparql_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :ISparql ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/isparql_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ISparql VAD" ;
+	oplvad:hasPackageName "ISparql"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "isparql_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :ISparql ;
+	wdrs:describedby source: .
 
 ### HTML5 PivotViewer
 
 :Html5PivotViewer a doap:Project, schema:SoftwareApplication ;
-  doap:name "Html5PivotViewer" ;
-  doap:description """HTML5 PivotViewer Bridge""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :Html5PivotViewerGitRepo ;
-  oplvad:hasVadPackage :Html5PivotViewerVad ;
-  wdrs:describedby source: .
+	doap:name "Html5PivotViewer" ;
+	doap:description """HTML5 PivotViewer Bridge""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :Html5PivotViewerGitRepo ;
+	oplvad:hasVadPackage :Html5PivotViewerVad ;
+	wdrs:describedby source: .
 
 :Html5PivotViewerGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Html5PivotViewer Git Repository" ;
+	wdrs:describedby source: .
 
 :Html5PivotViewerVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/fct_pivot_bridge_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Html5PivotViewer VAD" ;
-  oplvad:hasPackageName "Html5PivotViewer"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "isparql_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Html5PivotViewer ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/fct_pivot_bridge_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Html5PivotViewer VAD" ;
+	oplvad:hasPackageName "Html5PivotViewer"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "isparql_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Html5PivotViewer ;
+	wdrs:describedby source: .
 
 ### Schools Database
 
 :Schools a doap:Project, schema:SoftwareApplication ;
-  doap:name "SchoolsDatabase" ;
-  doap:description """Schools Database""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :SchoolsGitRepo ;
-  oplvad:hasVadPackage :SchoolsVad ;
-  wdrs:describedby source: .
+	doap:name "SchoolsDatabase" ;
+	doap:description """Schools Database""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :SchoolsGitRepo ;
+	oplvad:hasVadPackage :SchoolsVad ;
+	wdrs:describedby source: .
 
 :SchoolsGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "SchoolsDatabase Git Repository" ;
+	wdrs:describedby source: .
 
 :SchoolsVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/schools_db_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Schools VAD" ;
-  oplvad:hasPackageName "Schools"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "schools_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Schools ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/schools_db_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Schools VAD" ;
+	oplvad:hasPackageName "Schools"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "schools_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Schools ;
+	wdrs:describedby source: .
 
 ### OAT Applications
 
 :Oat a doap:Project, schema:SoftwareApplication ;
-  doap:name "Oat" ;
-  doap:description """OAT Applications""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :OatGitRepo ;
-  oplvad:hasVadPackage :OatVad ;
-  wdrs:describedby source: .
+	doap:name "Oat" ;
+	doap:description """OAT Applications""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :OatGitRepo ;
+	oplvad:hasVadPackage :OatVad ;
+	wdrs:describedby source: .
 
 :OatGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Oat Git Repository" ;
+	wdrs:describedby source: .
 
 :OatVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/oat_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Oat VAD" ;
-  oplvad:hasPackageName "Oat"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "oat_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Oat ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/oat_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Oat VAD" ;
+	oplvad:hasPackageName "Oat"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "oat_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Oat ;
+	wdrs:describedby source: .
 
 ### R2RML
 
 :R2RML a doap:Project, schema:SoftwareApplication ;
-  doap:name "R2RML" ;
-  doap:description """R2RML Processor Module""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :R2RMLRepo ;
-  oplvad:hasVadPackage :R2RMLVad ;
-  wdrs:describedby source: .
+	doap:name "R2RML" ;
+	doap:description """R2RML Processor Module""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :R2RMLRepo ;
+	oplvad:hasVadPackage :R2RMLVad ;
+	wdrs:describedby source: .
 
 :R2RMLGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "R2RML Git Repository" ;
+	wdrs:describedby source: .
 
 :R2RMLVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/rdb2rdf_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "R2RML VAD" ;
-  oplvad:hasPackageName "R2RML"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "rdb2rdf_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :R2RML ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/rdb2rdf_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "R2RML VAD" ;
+	oplvad:hasPackageName "R2RML"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "rdb2rdf_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :R2RML ;
+	wdrs:describedby source: .
 
 ### SPARQL to CXML Bridge
 
 :SparqlCxml a doap:Project, schema:SoftwareApplication ;
-  doap:name "SparqlCxml" ;
-  doap:description """SPARQL to CXML Bridge""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :SparqlCxmlRepo ;
-  oplvad:hasVadPackage :SparqlCxmlVad ;
-  wdrs:describedby source: .
+	doap:name "SparqlCxml" ;
+	doap:description """SPARQL to CXML Bridge""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :SparqlCxmlRepo ;
+	oplvad:hasVadPackage :SparqlCxmlVad ;
+	wdrs:describedby source: .
 
 :SparqlCxmlGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "SparqlCxml Git Repository" ;
+	wdrs:describedby source: .
 
 :SparqlCxmlVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/sparql_cxml_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "SparqlCxml VAD" ;
-  oplvad:hasPackageName "SparqlCxml"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "sparql_cxml_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :SparqlCxml ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/sparql_cxml_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "SparqlCxml VAD" ;
+	oplvad:hasPackageName "SparqlCxml"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "sparql_cxml_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :SparqlCxml ;
+	wdrs:describedby source: .
 
 ### SyncML Handler
 
 :SyncML a doap:Project, schema:SoftwareApplication ;
-  doap:name "SyncML" ;
-  doap:description """SyncML Handler""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :SyncMLRepo ;
-  oplvad:hasVadPackage :SyncMLVad ;
-  wdrs:describedby source: .
+	doap:name "SyncML" ;
+	doap:description """SyncML Handler""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :SyncMLRepo ;
+	oplvad:hasVadPackage :SyncMLVad ;
+	wdrs:describedby source: .
 
 :SyncMLGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "SyncML Git Repository" ;
+	wdrs:describedby source: .
 
 :SyncMLVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/syncml_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "SyncML VAD" ;
-  oplvad:hasPackageName "SyncML"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "syncml_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :SyncML ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/syncml_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "SyncML VAD" ;
+	oplvad:hasPackageName "SyncML"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "syncml_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :SyncML ;
+	wdrs:describedby source: .
 
 ### URL Shortener
 
 :CUri a doap:Project, schema:SoftwareApplication ;
-  doap:name "CUri" ;
-  doap:description """URL Shortener""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :CUriRepo ;
-  oplvad:hasVadPackage :CUriVad ;
-  wdrs:describedby source: .
+	doap:name "CUri" ;
+	doap:description """URL Shortener""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :CUriRepo ;
+	oplvad:hasVadPackage :CUriVad ;
+	wdrs:describedby source: .
 
 :CUriGitRepo a doap:GitRepository ;
-  schema:name "Curi Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "CUri Git Repository" ;
+	wdrs:describedby source: .
 
 :CUriVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.1/c_uri_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "CUri VAD" ;
-  oplvad:hasPackageName "CUri"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "c_uri_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :CUri ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.1/c_uri_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "CUri VAD" ;
+	oplvad:hasPackageName "CUri"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "c_uri_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :CUri ;
+	wdrs:describedby source: .
 
 
 ### phpBB3 Hosting & Deployment
 
 :Phpbb3 a doap:Project, schema:SoftwareApplication ;
-  doap:name "Phpbb3" ;
-  doap:description """phpBB3 Hosting & Deployment""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :Phpbb3Repo ;
-  oplvad:hasVadPackage :Phpbb3Vad ;
-  wdrs:describedby source: .
+	doap:name "Phpbb3" ;
+	doap:description """phpBB3 Hosting & Deployment""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :Phpbb3Repo ;
+	oplvad:hasVadPackage :Phpbb3Vad ;
+	wdrs:describedby source: .
 
 :Phpbb3GitRepo a doap:GitRepository ;
-  schema:name " phpBB3 Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "phpBB3 Git Repository" ;
+	wdrs:describedby source: .
 
 :Phpbb3Vad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/phpBB3_fs.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Phpbb3 VAD" ;
-  oplvad:hasPackageName "Phpbb3"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "phpBB3_fs.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Phpbb3 ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/phpBB3_fs.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Phpbb3 VAD" ;
+	oplvad:hasPackageName "Phpbb3"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "phpBB3_fs.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Phpbb3 ;
+	wdrs:describedby source: .
 
 ### MediaWiki Hosting & Deployment
 
 :MediaWiki a doap:Project, schema:SoftwareApplication ;
-  doap:name "MediaWiki" ;
-  doap:description """MediaWiki Hosting & Deployment""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :MediaWikiRepo ;
-  oplvad:hasVadPackage :MediaWikiVad ;
-  wdrs:describedby source: .
+	doap:name "MediaWiki" ;
+	doap:description """MediaWiki Hosting & Deployment""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :MediaWikiRepo ;
+	oplvad:hasVadPackage :MediaWikiVad ;
+	wdrs:describedby source: .
 
 :MediaWikiGitRepo a doap:GitRepository ;
-  schema:name "MediaWiki Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "MediaWiki Git Repository" ;
+	wdrs:describedby source: .
 
 :MediaWikiVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/mediawiki_fs.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "MediaWiki VAD" ;
-  oplvad:hasPackageName "MediaWiki"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "mediawiki_fs.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :MediaWiki ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/mediawiki_fs.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "MediaWiki VAD" ;
+	oplvad:hasPackageName "MediaWiki"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "mediawiki_fs.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :MediaWiki ;
+	wdrs:describedby source: .
 
 ### Wordpress Hosting & Deployment
 
 :Wordpress a doap:Project, schema:SoftwareApplication ;
-  doap:name "Wordpress" ;
-  doap:description """Wordpress Hosting & Deployment""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :WordpressRepo ;
-  oplvad:hasVadPackage :WordpressVad ;
-  wdrs:describedby source: .
+	doap:name "Wordpress" ;
+	doap:description """Wordpress Hosting & Deployment""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :WordpressRepo ;
+	oplvad:hasVadPackage :WordpressVad ;
+	wdrs:describedby source: .
 
 :WordpressGitRepo a doap:GitRepository ;
-  schema:name "Wordpress Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Wordpress Git Repository" ;
+	wdrs:describedby source: .
 
 :WordpressVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/wordpress_fs.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Wordpress VAD" ;
-  oplvad:hasPackageName "Wordpress"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "wordpress_fs.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Wordpress ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/wordpress_fs.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Wordpress VAD" ;
+	oplvad:hasPackageName "Wordpress"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "wordpress_fs.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Wordpress ;
+	wdrs:describedby source: .
 
 ### SPASQLQB VAD
 
 :Spasqlqb a doap:Project, schema:SoftwareApplication ;
-  doap:name "Spasqlqb" ;
-  doap:description """SPASQL Query Builder""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :SpasqlqbRepo ;
-  oplvad:hasVadPackage :SpasqlqbVad ;
-  wdrs:describedby source: .
+	doap:name "Spasqlqb" ;
+	doap:description """SPASQL Query Builder""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :SpasqlqbRepo ;
+	oplvad:hasVadPackage :SpasqlqbVad ;
+	wdrs:describedby source: .
 
 :SpasqlqbGitRepo a doap:GitRepository ;
-  schema:name "Spasqlqb Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Spasqlqb Git Repository" ;
+	wdrs:describedby source: .
 
 :SpasqlqbVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/spasqlqb_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Spasqlqb VAD" ;
-  oplvad:hasPackageName "Spasqlqb"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "spasqlqb_fs.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Spasqlqb ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/spasqlqb_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Spasqlqb VAD" ;
+	oplvad:hasPackageName "Spasqlqb"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "spasqlqb_fs.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Spasqlqb ;
+	wdrs:describedby source: .
 
 ### SPASQLQB VAD
 
 :Spasqlqb a doap:Project, schema:SoftwareApplication ;
-  doap:name "Spasqlqb" ;
-  doap:description """SPASQL Query Builder""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :SpasqlqbRepo ;
-  oplvad:hasVadPackage :SpasqlqbVad ;
-  wdrs:describedby source: .
+	doap:name "Spasqlqb" ;
+	doap:description """SPASQL Query Builder""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :SpasqlqbRepo ;
+	oplvad:hasVadPackage :SpasqlqbVad ;
+	wdrs:describedby source: .
 
 :SpasqlqbGitRepo a doap:GitRepository ;
-  schema:name "Spasqlqb Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Spasqlqb Git Repository" ;
+	wdrs:describedby source: .
 
 :SpasqlqbVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/spasqlqb_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Spasqlqb VAD" ;
-  oplvad:hasPackageName "Spasqlqb"^^xsd:string ;
-  # oplvad:hasOptionalDependency :Vad ;
-  oplvad:hasFileName "spasqlqb_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Spasqlqb ;
-  wdrs:describedby source: .
+	schema:url <http://download3.openlinksw.com/uda/vad-packages/8.3/spasqlqb_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Spasqlqb VAD" ;
+	oplvad:hasPackageName "Spasqlqb"^^xsd:string ;
+	# oplvad:hasOptionalDependency :Vad ;
+	oplvad:hasFileName "spasqlqb_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Spasqlqb ;
+	wdrs:describedby source: .
 
 ### Support System
 
 :SupportSystem a doap:Project, schema:SoftwareApplication ;
-  doap:name "Support System" ;
-  doap:description """Support Case Management Application.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :SupportSystemGitRepo ;
-  oplvad:hasVadPackage :SupportSystemVad ;
-  wdrs:describedby source: .
+	doap:name "Support System" ;
+	doap:description """Support Case Management Application.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :SupportSystemGitRepo ;
+	oplvad:hasVadPackage :SupportSystemVad ;
+	wdrs:describedby source: .
 
 :SupportSystemGitRepo a doap:GitRepository ;
-  schema:name "Support System Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Support System Git Repository" ;
+	wdrs:describedby source: .
 
 :SupportSystemVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  # schema:url <https://devhub.openlinksw.com/pub/OpenLink/VAD/support_system_dav.vad> ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Support System VAD" ;
-  oplvad:hasPackageName "support_system"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsuiVad ;
-  oplvad:hasMandatoryDependency :VALVad ;
-  oplvad:hasMandatoryDependency :InclusiontEngineVad ;
-  oplvad:hasFileName "support_system_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :SupportSystem ;
-  wdrs:describedby source: .
+	# schema:url <https://devhub.openlinksw.com/pub/OpenLink/VAD/support_system_dav.vad> ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Support System VAD" ;
+	oplvad:hasPackageName "support_system"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsuiVad ;
+	oplvad:hasMandatoryDependency :VALVad ;
+	oplvad:hasMandatoryDependency :InclusionEngineVad ;
+	oplvad:hasFileName "support_system_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :SupportSystem ;
+	wdrs:describedby source: .
 
 ### License Generator
 
 :LicenseGenerator a doap:Project, schema:SoftwareApplication ;
-  doap:name "License Generator" ;
-  doap:description """Evaluation License Generator and Download Application.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :LicenseGeneratorGitRepo ;
-  oplvad:hasVadPackage :LicenseGeneratorVad ;
-  wdrs:describedby source: .
+	doap:name "License Generator" ;
+	doap:description """Evaluation License Generator and Download Application.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :LicenseGeneratorGitRepo ;
+	oplvad:hasVadPackage :LicenseGeneratorVad ;
+	wdrs:describedby source: .
 
 :LicenseGeneratorGitRepo a doap:GitRepository ;
-  schema:name "License Generator Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "License Generator Git Repository" ;
+	wdrs:describedby source: .
 
 :LicenseGeneratorVad a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "License Generator Engine VAD" ;
-  oplvad:hasPackageName "license_generator"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsuiVad ;
-  oplvad:hasMandatoryDependency :VALVad ;
-  oplvad:hasMandatoryDependency :InclusiontEngineVad ;
-  oplvad:hasMandatoryDependency :Log4VirtuosoVad ;
-  oplvad:hasFileName "license_generator_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :LicenseGenerator ;
-  wdrs:describedby source: .
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "License Generator Engine VAD" ;
+	oplvad:hasPackageName "license_generator"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsuiVad ;
+	oplvad:hasMandatoryDependency :VALVad ;
+	oplvad:hasMandatoryDependency :InclusionEngineVad ;
+	oplvad:hasMandatoryDependency :Log4VirtuosoVad ;
+	oplvad:hasFileName "license_generator_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :LicenseGenerator ;
+	wdrs:describedby source: .
 
 ### ODS-Profile
 
 :OdsProfile a doap:Project, schema:SoftwareApplication ;
-  doap:name "ODS Profile" ;
-  doap:description """ODS Profile provides a profile management web interface for ODS user accounts.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :OdsProfileGitRepo ;
-  oplvad:hasVadPackage :OdsProfileVad ;
-  wdrs:describedby source: .
+	doap:name "ODS Profile" ;
+	doap:description """ODS Profile provides a profile management web interface for ODS user accounts.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :OdsProfileGitRepo ;
+	oplvad:hasVadPackage :OdsProfileVad ;
+	wdrs:describedby source: .
 
 :OdsProfileGitRepo a doap:GitRepository ;
-  schema:name "ODS Profile Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "ODS Profile Git Repository" ;
+	wdrs:describedby source: .
 
 :OdsProfileVad
-  # schema:url <https://devhub.openlinksw.com/pub/OpenLink/VAD/ods_profile_dav.vad> ;
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "ODS Profile VAD" ;
-  oplvad:hasPackageName "ods-profie"^^xsd:string ;
-  oplvad:hasFileName "ods_profile_dav.vad"^^xsd:string ;
-  oplvad:hasMandatoryDependency :OdsuiVad ;
-  oplvad:isVadPackageOf :OdsProfile ;
-  wdrs:describedby source: .
+	# schema:url <https://devhub.openlinksw.com/pub/OpenLink/VAD/ods_profile_dav.vad> ;
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "ODS Profile VAD" ;
+	oplvad:hasPackageName "ods-profile"^^xsd:string ;
+	oplvad:hasFileName "ods_profile_dav.vad"^^xsd:string ;
+	oplvad:hasMandatoryDependency :OdsuiVad ;
+	oplvad:isVadPackageOf :OdsProfile ;
+	wdrs:describedby source: .
 
 ### OPL-Skins
 
 :OplSkins a doap:Project, schema:SoftwareApplication ;
-  doap:name "OpenLink Skins" ;
-  doap:description """OpenLink Skins Repository.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :OplSkinsGitRepo ;
-  oplvad:hasVadPackage :OplSkinsVad ;
-  wdrs:describedby source: .
+	doap:name "OpenLink Skins" ;
+	doap:description """OpenLink Skins Repository.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :OplSkinsGitRepo ;
+	oplvad:hasVadPackage :OplSkinsVad ;
+	wdrs:describedby source: .
 
 :OplSkinsGitRepo a doap:GitRepository ;
-  schema:name "OpenLink Skins Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "OpenLink Skins Git Repository" ;
+	wdrs:describedby source: .
 
 :OplSkinsVad
-  # schema:url <https://devhub.openlinksw.com/pub/OpenLink/VAD/opl-skins_dav.vad> ;
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "OpenLink Skins VAD" ;
-  oplvad:hasPackageName "opl-skins"^^xsd:string ;
-  oplvad:hasFileName "opl-skins_dav.vad"^^xsd:string ;
-  oplvad:hasMandatoryDependency :InclusiontEngineVad ;
-  oplvad:hasMandatoryDependency :OdsuiVad ;
-  oplvad:hasMandatoryDependency :OdsProfileVad ;
-  oplvad:isVadPackageOf :OplSkins ;
-  wdrs:describedby source: .
+	# schema:url <https://devhub.openlinksw.com/pub/OpenLink/VAD/opl-skins_dav.vad> ;
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "OpenLink Skins VAD" ;
+	oplvad:hasPackageName "opl-skins"^^xsd:string ;
+	oplvad:hasFileName "opl-skins_dav.vad"^^xsd:string ;
+	oplvad:hasMandatoryDependency :InclusionEngineVad ;
+	oplvad:hasMandatoryDependency :OdsuiVad ;
+	oplvad:hasMandatoryDependency :OdsProfileVad ;
+	oplvad:isVadPackageOf :OplSkins ;
+	wdrs:describedby source: .
 
 
 ### Log4Virtuoso
 
 :Log4Virtuoso a doap:Project, schema:SoftwareApplication ;
-  doap:name "Log4Virtuoso" ;
-  doap:description """Virtuoso logging and error handling system.""" ;
-  schema:author <http://www.openlinksw.com/#this> ;
-  doap:repository :Log4VirtusooGitRepo ;
-  oplvad:hasVadPackage :Log4VirtuosoVad ;
-  wdrs:describedby source: .
+	doap:name "Log4Virtuoso" ;
+	doap:description """Virtuoso logging and error handling system.""" ;
+	schema:author <http://www.openlinksw.com/#this> ;
+	doap:repository :Log4VirtusooGitRepo ;
+	oplvad:hasVadPackage :Log4VirtuosoVad ;
+	wdrs:describedby source: .
 
 :Log4VirtusooGitRepo a doap:GitRepository ;
-  schema:name "Log4Virtuoso Git Repository" ;
-  wdrs:describedby source: .
+	schema:name "Log4Virtuoso Git Repository" ;
+	wdrs:describedby source: .
 
 :Log4VirtusoVad
-  # schema:url <https://devhub.openlinksw.com/pub/OpenLink/VAD/log4virtuoso_dav.vad> ;
-  a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
-  schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
-  schema:name "Log4Virtuoso VAD" ;
-  oplvad:hasPackageName "Log4Virtuoso"^^xsd:string ;
-  oplvad:hasFileName "log4virtuoso_dav.vad"^^xsd:string ;
-  oplvad:isVadPackageOf :Log4Virtuoso ;
-  wdrs:describedby source: .
+	# schema:url <https://devhub.openlinksw.com/pub/OpenLink/VAD/log4virtuoso_dav.vad> ;
+	a oplvad:DAVVirtuosoApplicationPackage, oplinst:InstallerArchive ;
+	schema:softwareAddOn <http://data.openlinksw.com/oplweb/product/Virtuoso#this> ;
+	schema:name "Log4Virtuoso VAD" ;
+	oplvad:hasPackageName "Log4Virtuoso"^^xsd:string ;
+	oplvad:hasFileName "log4virtuoso_dav.vad"^^xsd:string ;
+	oplvad:isVadPackageOf :Log4Virtuoso ;
+	wdrs:describedby source: .
 


### PR DESCRIPTION
includes 
* space indents changed to tabs, throughout
* typos corrected, throughout
* mix of CR & LF & CRLF fixed (by github) to CRLF
* many incorrect `schema:name "Curi Git Repository"` fixed
* `source: schema:about :PersonalAssitantVad` changed to `source: schema:about :PA , :PAVad , :PAGitRepo`